### PR TITLE
Add SwiftUI lock screen widget sample app

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,59 @@
+// swift-tools-version: 5.9
+import PackageDescription
+import AppleProductTypes
+
+let package = Package(
+    name: "SimpleLockWidget",
+    platforms: [
+        .iOS(.v16)
+    ],
+    products: [
+        .iOSApplication(
+            name: "SimpleLockWidget",
+            targets: ["SimpleLockWidgetApp"],
+            bundleIdentifier: "com.example.simplelockwidget",
+            teamIdentifier: "ABCDE12345",
+            displayVersion: "1.0",
+            bundleVersion: "1",
+            appIcon: .placeholder(icon: .text("SL"), backgroundColor: .indigo),
+            accentColor: .presetColor(.indigo),
+            supportedDeviceFamilies: [
+                .phone
+            ],
+            supportedInterfaceOrientations: [
+                .portrait
+            ],
+            capabilities: [
+                .appGroups(["group.com.example.simplelockwidget"])
+            ],
+            extensions: [
+                .widget(
+                    name: "SimpleLockWidgetWidget",
+                    targets: ["LockScreenWidget"]
+                )
+            ]
+        )
+    ],
+    targets: [
+        .target(
+            name: "SharedConstants",
+            path: "Sources/Shared"
+        ),
+        .executableTarget(
+            name: "SimpleLockWidgetApp",
+            dependencies: ["SharedConstants"],
+            path: "Sources/AppModule",
+            resources: [
+                .process("Resources")
+            ]
+        ),
+        .target(
+            name: "LockScreenWidget",
+            dependencies: ["SharedConstants"],
+            path: "Sources/LockScreenWidget",
+            resources: [
+                .process("Resources")
+            ]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# CodexTest
+# SimpleLockWidget
+
+SimpleLockWidget est une application iOS écrite en SwiftUI qui permet d'afficher un texte personnalisé dans un widget de l'écran verrouillé (lock screen). L'application principale permet de modifier le texte et de demander une actualisation immédiate du widget.
+
+## Fonctionnalités
+
+- Interface simple pour saisir le texte à afficher.
+- Synchronisation du message entre l'application et le widget via App Groups.
+- Widget de l'écran verrouillé compatible avec les familles inline, rectangulaire et circulaire.
+- Aperçu rapide du rendu directement dans l'application.
+
+## Structure du projet
+
+Le projet est fourni sous la forme d'un package Swift qui peut être ouvert directement dans Xcode :
+
+- `Package.swift` : configuration du package, de l'application iOS et de l'extension widget.
+- `Sources/Shared` : constantes partagées entre l'application et le widget.
+- `Sources/AppModule` : code de l'application iOS (interface utilisateur, stockage du texte, aperçu).
+- `Sources/LockScreenWidget` : code du widget et de son fournisseur de timeline.
+
+## Prérequis
+
+- Xcode 14 ou version ultérieure.
+- iOS 16 ou version ultérieure pour exécuter le widget d'écran verrouillé.
+
+## Installation
+
+1. Ouvrez `Package.swift` dans Xcode (`File > Open...`).
+2. Lorsque le projet est chargé, sélectionnez la cible **SimpleLockWidget**.
+3. Dans les réglages de la cible, remplacez l'identifiant d'équipe (`ABCDE12345`) et l'identifiant d'application (`com.example.simplelockwidget`) par vos propres identifiants si nécessaire.
+4. Assurez-vous que l'identifiant du groupe d'applications (`group.com.example.simplelockwidget`) est créé dans votre compte développeur Apple et associé à la cible de l'application et du widget.
+5. Construisez et exécutez l'application sur un appareil ou simulateur iOS 16 ou supérieur.
+
+## Utilisation
+
+1. Lancez l'application et saisissez le texte souhaité.
+2. Attendez quelques instants que le widget se mette à jour automatiquement, ou appuyez sur **Forcer la mise à jour du widget** pour accélérer le rafraîchissement.
+3. Ajoutez le widget « SimpleLockWidget » à l'écran verrouillé (en mode personnalisation de l'écran verrouillé sur iOS 16).
+
+## Personnalisation
+
+- Modifiez la constante `SharedConstants.defaultMessage` pour changer le message par défaut.
+- Adaptez la vue `LockScreenWidgetEntryView` si vous souhaitez un style différent selon les familles de widgets.
+
+## Licence
+
+Ce projet est fourni à titre d'exemple pédagogique et peut être utilisé librement.

--- a/Sources/AppModule/ContentView.swift
+++ b/Sources/AppModule/ContentView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+import WidgetKit
+import SharedConstants
+
+struct ContentView: View {
+    @Binding var message: String
+    @FocusState private var isTextFieldFocused: Bool
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Texte du widget") {
+                    TextField("Message", text: $message, axis: .vertical)
+                        .focused($isTextFieldFocused)
+                        .lineLimit(3, reservesSpace: true)
+                        .onSubmit { isTextFieldFocused = false }
+                    Text("Le texte ci-dessus sera partagé avec le widget de l'écran verrouillé.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section("Aperçu rapide") {
+                    LockScreenPreview(message: message)
+                        .padding(.vertical, 4)
+                }
+
+                Section {
+                    Button {
+                        WidgetCenter.shared.reloadTimelines(ofKind: SharedConstants.widgetKind)
+                    } label: {
+                        Label("Forcer la mise à jour du widget", systemImage: "arrow.clockwise")
+                    }
+                } footer: {
+                    Text("Les widgets se mettent normalement à jour quelques instants après une modification. Utilisez ce bouton pour demander une actualisation immédiate.")
+                }
+            }
+            .navigationTitle("SimpleLockWidget")
+        }
+        .onChange(of: message) { _ in
+            WidgetCenter.shared.reloadTimelines(ofKind: SharedConstants.widgetKind)
+        }
+    }
+}
+
+private struct LockScreenPreview: View {
+    var message: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Group {
+                Text("Inline")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(message)
+                    .font(.callout)
+            }
+
+            Divider()
+
+            Group {
+                Text("Rectangulaire")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                ZStack {
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(Color(.secondarySystemBackground))
+                    Text(message)
+                        .font(.headline)
+                        .multilineTextAlignment(.center)
+                        .padding()
+                }
+                .frame(height: 96)
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentView(message: .constant(SharedConstants.defaultMessage))
+}

--- a/Sources/AppModule/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Sources/AppModule/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.360",
+          "green" : "0.318",
+          "blue" : "0.850",
+          "alpha" : "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Sources/AppModule/Resources/Assets.xcassets/Contents.json
+++ b/Sources/AppModule/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/AppModule/SimpleLockWidgetApp.swift
+++ b/Sources/AppModule/SimpleLockWidgetApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import SharedConstants
+
+@main
+struct SimpleLockWidgetApp: App {
+    @AppStorage(SharedConstants.widgetMessageKey, store: UserDefaults(suiteName: SharedConstants.appGroupIdentifier))
+    private var message = SharedConstants.defaultMessage
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView(message: $message)
+        }
+    }
+}

--- a/Sources/LockScreenWidget/LockScreenWidget.swift
+++ b/Sources/LockScreenWidget/LockScreenWidget.swift
@@ -1,0 +1,101 @@
+import WidgetKit
+import SwiftUI
+import SharedConstants
+
+struct LockScreenEntry: TimelineEntry {
+    let date: Date
+    let message: String
+
+    var circularDisplayText: String {
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "SLW" }
+
+        let words = trimmed.split(separator: " ").prefix(3)
+        let initials = words.compactMap { $0.first }.map(String.init).joined()
+        if initials.isEmpty {
+            return String(trimmed.prefix(3)).uppercased()
+        }
+
+        return initials.uppercased()
+    }
+}
+
+struct LockScreenProvider: TimelineProvider {
+    func placeholder(in context: Context) -> LockScreenEntry {
+        LockScreenEntry(date: Date(), message: SharedConstants.defaultMessage)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (LockScreenEntry) -> Void) {
+        completion(makeEntry())
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<LockScreenEntry>) -> Void) {
+        let entry = makeEntry()
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date()) ?? Date().addingTimeInterval(900)
+        completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
+    }
+
+    private func makeEntry() -> LockScreenEntry {
+        let defaults = UserDefaults(suiteName: SharedConstants.appGroupIdentifier)
+        let storedMessage = defaults?.string(forKey: SharedConstants.widgetMessageKey) ?? SharedConstants.defaultMessage
+        let finalMessage = storedMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        return LockScreenEntry(date: Date(), message: finalMessage.isEmpty ? SharedConstants.defaultMessage : finalMessage)
+    }
+}
+
+struct LockScreenWidgetEntryView: View {
+    var entry: LockScreenProvider.Entry
+    @Environment(\.widgetFamily) private var family
+
+    var body: some View {
+        switch family {
+        case .accessoryCircular:
+            ZStack {
+                AccessoryWidgetBackground()
+                Text(entry.circularDisplayText)
+                    .font(.system(.title3, design: .rounded))
+                    .minimumScaleFactor(0.5)
+            }
+        case .accessoryInline:
+            Text(entry.message)
+        case .accessoryRectangular:
+            VStack(spacing: 6) {
+                Text(entry.message)
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+                    .minimumScaleFactor(0.6)
+                Text("SimpleLockWidget")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        @unknown default:
+            Text(entry.message)
+        }
+    }
+}
+
+struct LockScreenWidget: Widget {
+    let kind: String = SharedConstants.widgetKind
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: LockScreenProvider()) { entry in
+            LockScreenWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Texte personnalisé")
+        .description("Affiche votre texte dans l'écran verrouillé.")
+        .supportedFamilies([.accessoryCircular, .accessoryInline, .accessoryRectangular])
+    }
+}
+
+#Preview(as: .accessoryRectangular, widget: LockScreenWidget()) {
+    LockScreenEntry(date: .now, message: "Un exemple de message")
+}
+
+#Preview(as: .accessoryInline, widget: LockScreenWidget()) {
+    LockScreenEntry(date: .now, message: "Inline preview")
+}
+
+#Preview(as: .accessoryCircular, widget: LockScreenWidget()) {
+    LockScreenEntry(date: .now, message: "Bonjour")
+}

--- a/Sources/LockScreenWidget/LockScreenWidgetBundle.swift
+++ b/Sources/LockScreenWidget/LockScreenWidgetBundle.swift
@@ -1,0 +1,9 @@
+import WidgetKit
+import SwiftUI
+
+@main
+struct LockScreenWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        LockScreenWidget()
+    }
+}

--- a/Sources/LockScreenWidget/Resources/README.md
+++ b/Sources/LockScreenWidget/Resources/README.md
@@ -1,0 +1,1 @@
+Ce dossier peut accueillir des ressources spécifiques au widget (images, assets, etc.).

--- a/Sources/Shared/SharedConstants.swift
+++ b/Sources/Shared/SharedConstants.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum SharedConstants {
+    public static let appGroupIdentifier = "group.com.example.simplelockwidget"
+    public static let widgetKind = "LockScreenWidget"
+    public static let widgetMessageKey = "widgetMessage"
+    public static let defaultMessage = "Bonjour depuis SimpleLockWidget !"
+}


### PR DESCRIPTION
## Summary
- add a Swift Package Manager project that configures the SimpleLockWidget iOS app and widget extension
- implement the SwiftUI app with shared constants and a form to edit the message shown on the lock screen
- create the WidgetKit timeline provider and views to render the message in lock screen widget families

## Testing
- `swift package describe` *(fails on Linux because the AppleProductTypes manifest API is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9550471883298b27dcf71f08fcff